### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/top_pytest.py
+++ b/top_pytest.py
@@ -4,7 +4,7 @@ import httpx
 max_count = 201
 
 def main():
-    data_source = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages-30-days.min.json'
+    data_source = 'https://hugovk.github.io/top-pypi-packages/top-pypi-packages.min.json'
     r = httpx.get(data_source)
     assert r.status_code == 200
 


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.